### PR TITLE
Fix whitespace control in README generation

### DIFF
--- a/.readme/README.md.j2
+++ b/.readme/README.md.j2
@@ -2,10 +2,22 @@
 {%- set operator_name="edc" -%}
 {%- set related_reading_links=[] -%}
 
-{% include "partials/borrowed/header.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/header.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/main.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/links.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/footer.md.j2" %}
+{% filter trim %}
+  {%- include "partials/main.md.j2" -%}
+{% endfilter %}
 
-{% include "partials/borrowed/related_reading.md.j2" %}
+{% filter trim %}
+  {%- include "partials/borrowed/footer.md.j2" -%}
+{% endfilter %}
+
+{% filter trim %}
+  {%- include "partials/borrowed/related_reading.md.j2" -%}
+{% endfilter %}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["rust/operator-binary"]
+resolver = "2"
 
 [workspace.package]
 version = "0.0.0-dev"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@
 
 <h1 align="center">Stackable EDC Operator Technology Preview</h1>
 
+![Build Actions Status](https://ci.stackable.tech/buildStatus/icon?job=edc%2doperator%2dit%2dnightly&subject=Integration%20Tests)
+[![Maintenance](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://GitHub.com/stackabletech/edc-operator/graphs/commit-activity)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-green.svg)](https://docs.stackable.tech/home/stable/contributor/index.html)
+[![License OSL3.0](https://img.shields.io/badge/license-OSL3.0-green)](./LICENSE)
+
+[Documentation](https://docs.stackable.tech//stable/index.html) | [Stackable Data Platform](https://stackable.tech/) | [Platform Docs](https://docs.stackable.tech/) | [Discussions](https://github.com/orgs/stackabletech/discussions) | [Discord](https://discord.gg/7kZ3BNnCAF)
+
 This is a Kubernetes Operator for the [EDC Connector](https://github.com/eclipse-edc/Connector) (Eclipse Dataspace Components Connector).
 It is built with the [IONOS S3 extension](https://github.com/Digital-Ecosystems/edc-ionos-s3).
 
 A demo can be run from the `demo` directory, follow the README file in that directory for more information.
 
 The `jar` file that the Operator runs is built from the `edc-connector` repository.
-
 
 ## About The Stackable Data Platform
 


### PR DESCRIPTION
# Description

So far we would include files with all their whitespace which can lead to markdownlint errors and inconsistencies. Now we trim everything we include.

This also switches to resolver v2 for the workspace because the render-readme step would warn about it.

Part of https://github.com/stackabletech/issues/issues/492